### PR TITLE
feat: implement out-of-order block delivery handling (#27)

### DIFF
--- a/docs/2pc-protocol.md
+++ b/docs/2pc-protocol.md
@@ -424,9 +424,30 @@ func validateRwVariable(txID string, rw RwVariable) bool {
 
 **Problem:** State Shard processes Block N+1 before Block N.
 
-**Current behavior:** Not handled - assumes in-order delivery.
+**Solution:** Implemented `BlockBuffer` that handles out-of-order delivery by buffering blocks that arrive ahead of sequence.
 
-**TODO:** Track expected block height, buffer out-of-order blocks. See [GitHub issue #27](https://github.com/The-Sharding-Resurrection/test_v1/issues/27).
+**Implementation:**
+- `BlockBuffer`: Tracks expected block height and buffers out-of-order blocks
+- `maxBuffer`: Limits buffered blocks (default: 100) to prevent memory exhaustion
+- Blocks are released in order once gaps are filled
+
+**Behavior:**
+- If block.Height == expected: process immediately, then drain any buffered successors
+- If block.Height > expected: buffer for later (if within maxBuffer limit)
+- If block.Height < expected: ignore (duplicate or already processed)
+
+```go
+// In handleOrchestratorShardBlock:
+blocksToProcess := s.blockBuffer.ProcessBlock(&block)
+if blocksToProcess == nil {
+    // Block was buffered or ignored
+    return
+}
+// Process all blocks returned by buffer (in order)
+for _, b := range blocksToProcess {
+    s.processOrchestratorBlock(b)
+}
+```
 
 ## Comparison with HTTP-Based 2PC
 

--- a/internal/shard/block_buffer.go
+++ b/internal/shard/block_buffer.go
@@ -1,0 +1,122 @@
+package shard
+
+import (
+	"log"
+	"sync"
+
+	"github.com/sharding-experiment/sharding/internal/protocol"
+)
+
+// BlockBuffer handles out-of-order orchestrator block delivery by buffering
+// blocks that arrive ahead of sequence and releasing them when gaps are filled.
+type BlockBuffer struct {
+	mu        sync.Mutex
+	expected  uint64                                    // Next expected block height
+	buffered  map[uint64]*protocol.OrchestratorShardBlock // Out-of-order blocks waiting to be processed
+	maxBuffer int                                       // Maximum number of blocks to buffer
+	shardID   int                                       // For logging
+}
+
+// NewBlockBuffer creates a new BlockBuffer.
+// startHeight is the first block height expected (typically 1, after genesis).
+// maxBuffer limits memory usage by capping buffered blocks.
+func NewBlockBuffer(shardID int, startHeight uint64, maxBuffer int) *BlockBuffer {
+	return &BlockBuffer{
+		expected:  startHeight,
+		buffered:  make(map[uint64]*protocol.OrchestratorShardBlock),
+		maxBuffer: maxBuffer,
+		shardID:   shardID,
+	}
+}
+
+// ProcessBlock handles an incoming orchestrator block and returns blocks ready
+// to be processed in order. Returns nil if the block was buffered or ignored.
+//
+// Behavior:
+// - If block.Height == expected: process immediately, then drain any buffered successors
+// - If block.Height > expected: buffer for later (if within maxBuffer limit)
+// - If block.Height < expected: ignore (duplicate or already processed)
+func (b *BlockBuffer) ProcessBlock(block *protocol.OrchestratorShardBlock) []*protocol.OrchestratorShardBlock {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if block.Height == b.expected {
+		// Block is next in sequence - process it and any buffered successors
+		result := []*protocol.OrchestratorShardBlock{block}
+		b.expected++
+
+		// Drain buffered blocks that are now in sequence
+		for {
+			next, ok := b.buffered[b.expected]
+			if !ok {
+				break
+			}
+			result = append(result, next)
+			delete(b.buffered, b.expected)
+			b.expected++
+			log.Printf("Shard %d: BlockBuffer released buffered block %d", b.shardID, b.expected-1)
+		}
+
+		return result
+	}
+
+	if block.Height > b.expected {
+		// Block arrived out of order - buffer it
+		gap := block.Height - b.expected
+
+		// Check buffer limit to prevent memory exhaustion
+		if len(b.buffered) >= b.maxBuffer {
+			log.Printf("Shard %d: BlockBuffer full (%d blocks), dropping block %d (expected %d)",
+				b.shardID, len(b.buffered), block.Height, b.expected)
+			return nil
+		}
+
+		// Don't buffer if already have this block
+		if _, exists := b.buffered[block.Height]; exists {
+			log.Printf("Shard %d: BlockBuffer already has block %d buffered", b.shardID, block.Height)
+			return nil
+		}
+
+		b.buffered[block.Height] = block
+		log.Printf("Shard %d: BlockBuffer buffered block %d (expected %d, gap=%d, buffered=%d)",
+			b.shardID, block.Height, b.expected, gap, len(b.buffered))
+		return nil
+	}
+
+	// block.Height < b.expected - old/duplicate block
+	log.Printf("Shard %d: BlockBuffer ignoring old block %d (expected %d)",
+		b.shardID, block.Height, b.expected)
+	return nil
+}
+
+// GetExpected returns the next expected block height.
+func (b *BlockBuffer) GetExpected() uint64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.expected
+}
+
+// GetBufferedCount returns the number of currently buffered blocks.
+func (b *BlockBuffer) GetBufferedCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.buffered)
+}
+
+// SetExpected sets the expected block height (used during recovery).
+func (b *BlockBuffer) SetExpected(height uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.expected = height
+}
+
+// GetBufferedHeights returns the heights of all currently buffered blocks (for debugging).
+func (b *BlockBuffer) GetBufferedHeights() []uint64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	heights := make([]uint64, 0, len(b.buffered))
+	for h := range b.buffered {
+		heights = append(heights, h)
+	}
+	return heights
+}

--- a/internal/shard/block_buffer_test.go
+++ b/internal/shard/block_buffer_test.go
@@ -1,0 +1,242 @@
+package shard
+
+import (
+	"testing"
+
+	"github.com/sharding-experiment/sharding/internal/protocol"
+)
+
+func makeTestOrchestratorBlock(height uint64) *protocol.OrchestratorShardBlock {
+	return &protocol.OrchestratorShardBlock{
+		Height:    height,
+		TpcResult: map[string]bool{},
+		CtToOrder: []protocol.CrossShardTx{},
+	}
+}
+
+func TestBlockBuffer_InOrderDelivery(t *testing.T) {
+	buf := NewBlockBuffer(0, 1, 100)
+
+	// Process blocks in order
+	for i := uint64(1); i <= 5; i++ {
+		block := makeTestOrchestratorBlock(i)
+		result := buf.ProcessBlock(block)
+
+		if len(result) != 1 {
+			t.Errorf("Block %d: expected 1 block, got %d", i, len(result))
+		}
+		if result[0].Height != i {
+			t.Errorf("Block %d: expected height %d, got %d", i, i, result[0].Height)
+		}
+	}
+
+	if buf.GetExpected() != 6 {
+		t.Errorf("Expected next height 6, got %d", buf.GetExpected())
+	}
+	if buf.GetBufferedCount() != 0 {
+		t.Errorf("Expected 0 buffered blocks, got %d", buf.GetBufferedCount())
+	}
+}
+
+func TestBlockBuffer_OutOfOrderDelivery(t *testing.T) {
+	buf := NewBlockBuffer(0, 1, 100)
+
+	// Receive block 3 first (out of order)
+	block3 := makeTestOrchestratorBlock(3)
+	result := buf.ProcessBlock(block3)
+	if result != nil {
+		t.Errorf("Block 3 should be buffered, got %d blocks", len(result))
+	}
+	if buf.GetBufferedCount() != 1 {
+		t.Errorf("Expected 1 buffered block, got %d", buf.GetBufferedCount())
+	}
+
+	// Receive block 2 (still out of order)
+	block2 := makeTestOrchestratorBlock(2)
+	result = buf.ProcessBlock(block2)
+	if result != nil {
+		t.Errorf("Block 2 should be buffered, got %d blocks", len(result))
+	}
+	if buf.GetBufferedCount() != 2 {
+		t.Errorf("Expected 2 buffered blocks, got %d", buf.GetBufferedCount())
+	}
+
+	// Receive block 1 (fills the gap)
+	block1 := makeTestOrchestratorBlock(1)
+	result = buf.ProcessBlock(block1)
+	if len(result) != 3 {
+		t.Errorf("Expected 3 blocks (1, 2, 3), got %d", len(result))
+	}
+
+	// Verify order
+	for i, b := range result {
+		expectedHeight := uint64(i + 1)
+		if b.Height != expectedHeight {
+			t.Errorf("Block %d: expected height %d, got %d", i, expectedHeight, b.Height)
+		}
+	}
+
+	if buf.GetExpected() != 4 {
+		t.Errorf("Expected next height 4, got %d", buf.GetExpected())
+	}
+	if buf.GetBufferedCount() != 0 {
+		t.Errorf("Expected 0 buffered blocks after drain, got %d", buf.GetBufferedCount())
+	}
+}
+
+func TestBlockBuffer_DuplicateBlock(t *testing.T) {
+	buf := NewBlockBuffer(0, 1, 100)
+
+	// Process block 1
+	block1 := makeTestOrchestratorBlock(1)
+	result := buf.ProcessBlock(block1)
+	if len(result) != 1 {
+		t.Errorf("Expected 1 block, got %d", len(result))
+	}
+
+	// Try to process block 1 again (duplicate)
+	result = buf.ProcessBlock(block1)
+	if result != nil {
+		t.Errorf("Duplicate block should be ignored, got %d blocks", len(result))
+	}
+
+	if buf.GetExpected() != 2 {
+		t.Errorf("Expected next height 2, got %d", buf.GetExpected())
+	}
+}
+
+func TestBlockBuffer_OldBlock(t *testing.T) {
+	buf := NewBlockBuffer(0, 5, 100) // Start expecting block 5
+
+	// Receive old block 3
+	block3 := makeTestOrchestratorBlock(3)
+	result := buf.ProcessBlock(block3)
+	if result != nil {
+		t.Errorf("Old block should be ignored, got %d blocks", len(result))
+	}
+
+	if buf.GetExpected() != 5 {
+		t.Errorf("Expected should still be 5, got %d", buf.GetExpected())
+	}
+}
+
+func TestBlockBuffer_BufferLimit(t *testing.T) {
+	buf := NewBlockBuffer(0, 1, 3) // Only buffer 3 blocks
+
+	// Buffer blocks 2, 3, 4
+	buf.ProcessBlock(makeTestOrchestratorBlock(2))
+	buf.ProcessBlock(makeTestOrchestratorBlock(3))
+	buf.ProcessBlock(makeTestOrchestratorBlock(4))
+
+	if buf.GetBufferedCount() != 3 {
+		t.Errorf("Expected 3 buffered blocks, got %d", buf.GetBufferedCount())
+	}
+
+	// Try to buffer block 5 (should be dropped due to limit)
+	result := buf.ProcessBlock(makeTestOrchestratorBlock(5))
+	if result != nil {
+		t.Errorf("Block should be dropped due to buffer limit, got %d blocks", len(result))
+	}
+	if buf.GetBufferedCount() != 3 {
+		t.Errorf("Buffer count should still be 3, got %d", buf.GetBufferedCount())
+	}
+}
+
+func TestBlockBuffer_DuplicateBufferedBlock(t *testing.T) {
+	buf := NewBlockBuffer(0, 1, 100)
+
+	// Buffer block 3
+	buf.ProcessBlock(makeTestOrchestratorBlock(3))
+	if buf.GetBufferedCount() != 1 {
+		t.Errorf("Expected 1 buffered block, got %d", buf.GetBufferedCount())
+	}
+
+	// Try to buffer block 3 again
+	result := buf.ProcessBlock(makeTestOrchestratorBlock(3))
+	if result != nil {
+		t.Errorf("Duplicate buffered block should be ignored")
+	}
+	if buf.GetBufferedCount() != 1 {
+		t.Errorf("Buffer count should still be 1, got %d", buf.GetBufferedCount())
+	}
+}
+
+func TestBlockBuffer_PartialDrain(t *testing.T) {
+	buf := NewBlockBuffer(0, 1, 100)
+
+	// Buffer blocks 2, 3, 5 (gap at 4)
+	buf.ProcessBlock(makeTestOrchestratorBlock(2))
+	buf.ProcessBlock(makeTestOrchestratorBlock(3))
+	buf.ProcessBlock(makeTestOrchestratorBlock(5))
+
+	// Receive block 1 - should drain 1, 2, 3 but not 5 (gap at 4)
+	result := buf.ProcessBlock(makeTestOrchestratorBlock(1))
+	if len(result) != 3 {
+		t.Errorf("Expected 3 blocks (1, 2, 3), got %d", len(result))
+	}
+
+	if buf.GetExpected() != 4 {
+		t.Errorf("Expected next height 4, got %d", buf.GetExpected())
+	}
+	if buf.GetBufferedCount() != 1 {
+		t.Errorf("Expected 1 buffered block (block 5), got %d", buf.GetBufferedCount())
+	}
+
+	// Now receive block 4 - should drain 4, 5
+	result = buf.ProcessBlock(makeTestOrchestratorBlock(4))
+	if len(result) != 2 {
+		t.Errorf("Expected 2 blocks (4, 5), got %d", len(result))
+	}
+
+	if buf.GetExpected() != 6 {
+		t.Errorf("Expected next height 6, got %d", buf.GetExpected())
+	}
+	if buf.GetBufferedCount() != 0 {
+		t.Errorf("Expected 0 buffered blocks, got %d", buf.GetBufferedCount())
+	}
+}
+
+func TestBlockBuffer_SetExpected(t *testing.T) {
+	buf := NewBlockBuffer(0, 1, 100)
+
+	buf.SetExpected(10)
+	if buf.GetExpected() != 10 {
+		t.Errorf("Expected 10, got %d", buf.GetExpected())
+	}
+
+	// Block 9 should now be ignored (old)
+	result := buf.ProcessBlock(makeTestOrchestratorBlock(9))
+	if result != nil {
+		t.Errorf("Old block should be ignored")
+	}
+
+	// Block 10 should be processed
+	result = buf.ProcessBlock(makeTestOrchestratorBlock(10))
+	if len(result) != 1 {
+		t.Errorf("Expected 1 block, got %d", len(result))
+	}
+}
+
+func TestBlockBuffer_GetBufferedHeights(t *testing.T) {
+	buf := NewBlockBuffer(0, 1, 100)
+
+	buf.ProcessBlock(makeTestOrchestratorBlock(3))
+	buf.ProcessBlock(makeTestOrchestratorBlock(5))
+	buf.ProcessBlock(makeTestOrchestratorBlock(7))
+
+	heights := buf.GetBufferedHeights()
+	if len(heights) != 3 {
+		t.Errorf("Expected 3 heights, got %d", len(heights))
+	}
+
+	// Check all heights are present (order may vary)
+	heightMap := make(map[uint64]bool)
+	for _, h := range heights {
+		heightMap[h] = true
+	}
+	for _, expected := range []uint64{3, 5, 7} {
+		if !heightMap[expected] {
+			t.Errorf("Expected height %d in buffered heights", expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add BlockBuffer to handle orchestrator blocks that arrive out of sequence due to network delays or reordering
- Blocks are buffered until gaps are filled, then released in correct order for processing
- Prevents missing vote recording, premature commit/abort, and state inconsistencies

## Changes

### `internal/shard/block_buffer.go` (new)
- `BlockBuffer` struct tracks expected height and buffers ahead-of-sequence blocks
- `maxBuffer` (100) limits memory usage by capping buffered blocks
- `ProcessBlock()` returns nil if buffered, or returns all in-order blocks to process
- `GetExpected()`, `SetExpected()`, `GetBufferedCount()`, `GetBufferedHeights()` for introspection

### `internal/shard/server.go`
- Added `blockBuffer *BlockBuffer` to Server struct
- Refactored `handleOrchestratorShardBlock` to use buffer
- New `processOrchestratorBlock` helper for actual block processing

### `internal/shard/block_buffer_test.go` (new)
- Comprehensive tests for:
  - In-order delivery
  - Out-of-order delivery with gap filling
  - Duplicate blocks (processed and buffered)
  - Old blocks
  - Buffer limits
  - Partial drain

### `docs/2pc-protocol.md`
- Updated "Out-of-Order Blocks" section with implementation details

## Test plan

- [x] All existing shard tests pass
- [x] New BlockBuffer tests pass (`go test -v ./internal/shard/... -run "BlockBuffer"`)
- [ ] Manual testing with Docker network (optional)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)