### PR TITLE
fix: prevent map aliasing bugs in ProduceBlock functions

### DIFF
--- a/internal/shard/chain.go
+++ b/internal/shard/chain.go
@@ -353,15 +353,24 @@ func (c *Chain) ProduceBlock(evmState *EVMState) (*protocol.StateShardBlock, err
 		return nil, err
 	}
 
+	// Create defensive copies to avoid aliasing internal state
+	// This prevents races if the block is serialized/broadcast while internal state changes
+	prepareTxsCopy := make([]protocol.Transaction, len(c.prepareTxs))
+	copy(prepareTxsCopy, c.prepareTxs)
+	preparesCopy := make(map[string]bool, len(c.prepares))
+	for k, v := range c.prepares {
+		preparesCopy[k] = v
+	}
+
 	block := &protocol.StateShardBlock{
 		ShardID:    c.shardID,
 		Height:     c.height + 1,
 		PrevHash:   c.blocks[c.height].Hash(),
 		Timestamp:  uint64(time.Now().Unix()),
 		StateRoot:  stateRoot,
-		TxOrdering: successfulTxs,  // Only include successful transactions
-		PrepareTxs: c.prepareTxs,   // Include prepare operations for crash recovery
-		TpcPrepare: c.prepares,
+		TxOrdering: successfulTxs,  // Only include successful transactions (already a local slice)
+		PrepareTxs: prepareTxsCopy, // Defensive copy for crash recovery
+		TpcPrepare: preparesCopy,   // Defensive copy of prepare votes
 	}
 
 	c.blocks = append(c.blocks, block)


### PR DESCRIPTION
## Summary

- Fixes #51
- Prevents data races from map/slice aliasing in `ProduceBlock()` functions

## Problem

Both `OrchestratorChain.ProduceBlock()` and `StateShardChain.ProduceBlock()` were directly assigning internal maps and slices to block structs:

```go
// Before (BUGGY)
block := &protocol.OrchestratorShardBlock{
    TpcResult: c.pendingResult,  // Direct map reference
    CtToOrder: c.pendingTxs,     // Direct slice reference
}
```

This creates aliased references where the block shares the same underlying data as the chain's internal state. While the mutex is held during `ProduceBlock()`, the returned block is then broadcast and serialized outside the mutex, creating potential races.

## Solution

Create defensive copies before assignment:

```go
// After (SAFE)
tpcResultCopy := make(map[string]bool, len(c.pendingResult))
for k, v := range c.pendingResult {
    tpcResultCopy[k] = v
}

block := &protocol.OrchestratorShardBlock{
    TpcResult: tpcResultCopy,  // Isolated copy
    // ...
}
```

## Test plan

- [x] All existing tests pass (`go test ./internal/orchestrator/... ./internal/shard/...`)
- [x] Concurrent access tests continue to pass